### PR TITLE
Add `squared_error` to __all__

### DIFF
--- a/optax/__init__.py
+++ b/optax/__init__.py
@@ -339,6 +339,7 @@ __all__ = (
     "smooth_labels",
     "softmax_cross_entropy",
     "softmax_cross_entropy_with_integer_labels",
+    "squared_error",
     "stateless",
     "stateless_with_tree_map",
     "trace",


### PR DESCRIPTION
Currently `squared_error` is missing from `__all__` in `__init__.py`, this PR adds it.